### PR TITLE
change python-igraph to igraph

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,9 +6,9 @@ authors = ["Bastian Rieck <bastian.rieck@bsse.ethz.ch>"]
 
 [tool.poetry.dependencies]
 python = ">=3.6.1"
+igraph = ">=0.8.0"
 numpy = ">=1.18.1"
 pandas = ">=1.0.1"
-python-igraph = ">=0.8.0"
 scikit-learn = ">=0.23.2"
 setuptools = ">=63.2.0"
 


### PR DESCRIPTION
Please see https://github.com/igraph/python-igraph/issues/699 for the explanation.

Note that the oldest version available under the `igraph` name on PyPI is 0.9.8.